### PR TITLE
update sentry sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>io.sentry</groupId>
 			<artifactId>sentry</artifactId>
-			<version>6.14.0</version>
+			<version>6.34.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>io.sentry</groupId>
 			<artifactId>sentry</artifactId>
-			<version>6.34.0</version>
+			<version>7.6.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	</dependencyManagement>
 
 	<build>
-		<finalName>${project.groupId}-${project.artifactId}-${project.version}</finalName>
+		<finalName>keycloak-sentry-logger</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/dev/yakovlev_alexey/keycloak/events/SentryEventListener.java
+++ b/src/main/java/dev/yakovlev_alexey/keycloak/events/SentryEventListener.java
@@ -1,7 +1,6 @@
 package dev.yakovlev_alexey.keycloak.events;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -21,8 +20,8 @@ public class SentryEventListener implements EventListenerProvider {
 	private final IHub hub;
 	private final boolean errorsOnly;
 
-	private Set<String> ignoredEventTypes = new HashSet<>();
-	private Set<String> ignoredErrors = new HashSet<>();
+	private final Set<String> ignoredEventTypes;
+	private final Set<String> ignoredErrors;
 
 	SentryEventListener(IHub hub, SentryConfiguration configuration) {
 		this.hub = hub;
@@ -145,7 +144,10 @@ public class SentryEventListener implements EventListenerProvider {
 
 	private Map<String, Object> getExtras(Event event) {
 		HashMap<String, Object> extras = new HashMap<>();
-		extras.putAll(event.getDetails());
+
+		if (event.getDetails() != null) {
+			extras.putAll(event.getDetails());
+		}
 
 		extras.put("realmId", event.getRealmId());
 		extras.put("clientId", event.getClientId());

--- a/src/main/java/dev/yakovlev_alexey/keycloak/events/SentryEventListenerFactory.java
+++ b/src/main/java/dev/yakovlev_alexey/keycloak/events/SentryEventListenerFactory.java
@@ -19,7 +19,7 @@ public class SentryEventListenerFactory implements EventListenerProviderFactory 
 
 	@Override
 	public EventListenerProvider create(KeycloakSession session) {
-		Sentry.init();
+		Sentry.init(o -> o.setEnableUncaughtExceptionHandler(false));
 
 		SentryConfiguration configuration = new SentryEventListenerConfiguration();
 		IHub hub = Sentry.getCurrentHub();

--- a/src/main/java/dev/yakovlev_alexey/keycloak/events/SentryEventListenerFactory.java
+++ b/src/main/java/dev/yakovlev_alexey/keycloak/events/SentryEventListenerFactory.java
@@ -19,7 +19,10 @@ public class SentryEventListenerFactory implements EventListenerProviderFactory 
 
 	@Override
 	public EventListenerProvider create(KeycloakSession session) {
-		Sentry.init(o -> o.setEnableUncaughtExceptionHandler(false));
+		Sentry.init(o -> {
+			o.setEnableExternalConfiguration(true);
+			o.setEnableUncaughtExceptionHandler(false);
+		});
 
 		SentryConfiguration configuration = new SentryEventListenerConfiguration();
 		IHub hub = Sentry.getCurrentHub();


### PR DESCRIPTION
update sentry sdk version to include a fix which permits reading SENTRY_ENVIRONMENT env var properly

the previous version exhibited a bug where this environment variable was being ignored, upgrading to this later version provides a fix